### PR TITLE
Apply starvation damage only if player is not dead

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -234,7 +234,7 @@ local function stamina_globaltimer(dtime)
 			end
 
 			-- or damage player by 1 hp if saturation is < 2 (of 30)
-			if get_int_attribute(player, "stamina:level") < STAMINA_STARVE_LVL then
+			if get_int_attribute(player, "stamina:level") < STAMINA_STARVE_LVL and hp > 0 then
 				player:set_hp(hp - STAMINA_STARVE)
 			end
 		end


### PR DESCRIPTION
This prevents on_dieplayer being called unnecessarily, causing problems such as repeated death messages.