### PR TITLE
fix privilege check

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -42,7 +42,7 @@ local function stamina_update_level(player, level)
 	end
 
 	-- players without interact priv cannot eat
-	if old < STAMINA_HEAL_LVL and minetest.check_player_privs(player, {interact=false}) then
+	if old < STAMINA_HEAL_LVL and not minetest.check_player_privs(player, {interact=true}) then
 		return
 	end
 


### PR DESCRIPTION
The privilege check was backwards; This resulted in players with the interact privilege not being able to lose or gain stamina once their stamina dropped below the heal threshold. I assume players w/out interact would still starve to death :)

Note that `minetest.check_player_privs(player, {interact=false})` is semantically identical to `minetest.check_player_privs(player, {interact=true})`.