### PR TITLE
add nil check for replace_with_item

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -424,9 +424,11 @@ function minetest.do_item_eat(hp_change, replace_with_item, itemstack, player, p
 
 	local itemname = itemstack:get_name()
 	if replace_with_item then
-		stamina.log("action", "%s eats %s for %s stamina, replace with %s", player:get_player_name(), itemname, hp_change, replace_with_item)
+		stamina.log("action", "%s eats %s for %s stamina, replace with %s",
+			player:get_player_name(), itemname, hp_change, replace_with_item)
 	else
-		stamina.log("action", "%s eats %s for %s stamina", player:get_player_name(), itemname, hp_change)
+		stamina.log("action", "%s eats %s for %s stamina",
+			player:get_player_name(), itemname, hp_change)
 	end
 	minetest.sound_play("stamina_eat", {to_player = player:get_player_name(), gain = 0.7})
 

--- a/init.lua
+++ b/init.lua
@@ -423,8 +423,11 @@ function minetest.do_item_eat(hp_change, replace_with_item, itemstack, player, p
 	end
 
 	local itemname = itemstack:get_name()
-	stamina.log("action", "%s eats %s for %s stamina, replace with %s",
-			player:get_player_name(), itemname, hp_change, replace_with_item)
+	if replace_with_item then
+		stamina.log("action", "%s eats %s for %s stamina, replace with %s", player:get_player_name(), itemname, hp_change, replace_with_item)
+	else
+		stamina.log("action", "%s eats %s for %s stamina", player:get_player_name(), itemname, hp_change)
+	end
 	minetest.sound_play("stamina_eat", {to_player = player:get_player_name(), gain = 0.7})
 
 	if hp_change > 0 then


### PR DESCRIPTION
Currently, stamina will crash the server every time a player eats something, if the server is not using LuaJIT. This is because str:format in Lua5.1 will not interpret nil values, whereas LuaJIT will interpret them. 