### PR TITLE
use new player metadata API when available

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -59,9 +59,7 @@ local attribute = {
 
 local function is_player(player)
 	return (
-		player and
-		player.is_player and
-		player:is_player() and
+		minetest.is_player(player) and
 		not player.is_fake_player
 	)
 end


### PR DESCRIPTION
The old player metadata API is deprecated, so I've written some code to use the new API if it is available, but fall back to the old API if it is not. 