### PR TITLE
Add a setting to allow players with fast privilege to sprint.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -29,6 +29,7 @@ stamina.settings = {
 	sprint_lvl = get_setting("sprint_lvl", 6),
 	sprint_speed = get_setting("sprint_speed", 0.8),
 	sprint_jump = get_setting("sprint_jump", 0.1),
+	sprint_with_fast = minetest.settings:get_bool("stamina.sprint_with_fast", false),
 	tick = get_setting("tick", 800),
 	tick_min = get_setting("tick_min", 4),
 	health_tick = get_setting("health_tick", 4),
@@ -341,7 +342,7 @@ local function move_tick()
 			local can_sprint = (
 				controls.aux1 and
 				not player:get_attach() and
-				not minetest.check_player_privs(player, {fast = true}) and
+				(settings.sprint_with_fast or not minetest.check_player_privs(player, {fast = true})) and
 				stamina.get_saturation(player) > settings.sprint_lvl
 			)
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -21,3 +21,4 @@ stamina.visual_max       (hud bar only extends to 20)                           
 stamina.sprint_speed     (how much faster a player can run if satiated)           float 0.8  0 2
 stamina.sprint_jump      (how much faster a player can jump if satiated)          float 0.1  0 2
 stamina.eat_particles    (Whether to generate particles when eating)              bool true
+stamina.sprint_with_fast (Sprint when player has fast privilege?)                 bool false


### PR DESCRIPTION
As discussed in #30, I added the option `stamina.sprint_with_fast` to allow players with fast privilege to sprint.