### PR TITLE
Fix Poison Crash

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -164,8 +164,9 @@ function stamina.set_poisoned(player, poisoned)
 	end
 end
 
-local function poison_tick(player, ticks, interval, elapsed)
-	if not stamina.is_poisoned(player) then
+local function poison_tick(player_name, ticks, interval, elapsed)
+	local player = minetest.get_player_by_name(player_name)
+	if not player or not stamina.is_poisoned(player) then
 		return
 	elseif elapsed > ticks then
 		stamina.set_poisoned(player, false)
@@ -174,7 +175,7 @@ local function poison_tick(player, ticks, interval, elapsed)
 		if hp > 0 then
 			player:set_hp(hp)
 		end
-		minetest.after(interval, poison_tick, player, ticks, interval, elapsed + 1)
+		minetest.after(interval, poison_tick, player_name, ticks, interval, elapsed + 1)
 	end
 end
 
@@ -194,7 +195,8 @@ function stamina.poison(player, ticks, interval)
 		return
 	end
 	stamina.set_poisoned(player, true)
-	poison_tick(player, ticks, interval, 0)
+	local player_name = player:get_player_name()
+	poison_tick(player_name, ticks, interval, 0)
 end
 --- END POISON API ---
 --- EXHAUSTION API ---


### PR DESCRIPTION
Previously, the player object was stored for later usage which leads to a crash when a player leaves the server while being poisoned.