### PR TITLE
Player metadata compat

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -59,9 +59,7 @@ local attribute = {
 
 local function is_player(player)
 	return (
-		player and
-		player.is_player and
-		player:is_player() and
+		minetest.is_player(player) and
 		not player.is_fake_player
 	)
 end


### PR DESCRIPTION
Honestly, I wrote this so long ago that I don't remember why I didn't submit this PR then. It seems feature complete though. Basically, the changes are:

1) Use the new player metadata API if it's available, falling back to the old behaviour.
2) Don't store the stamina HUD ID as player metadata; just store it in memory.