### PR TITLE
Fix crash with latest Minetest-dev version by fixing the logical order

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -520,8 +520,8 @@ minetest.register_on_joinplayer(function(player)
 		offset = {x = -266, y = -110},
 		max = 0,
 	})
-	stamina.set_saturation(player, level)
 	set_hud_id(player, id)
+	stamina.set_saturation(player, level)
 	-- reset poisoned
 	stamina.set_poisoned(player, false)
 	-- remove legacy hud_id from player metadata


### PR DESCRIPTION
`stamina.set_saturation()` uses the hud id set for the player. Thus, the id should be set before calling this function.
Until now, it only worked because of undocumented behaviour. See minetest/minetest#10568