### PR TITLE
Mitigate crash if metadata is not valid (disconnected player?)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -78,7 +78,8 @@ end
 
 local function get_player_attribute(player, key)
 	if player.get_meta then
-		return player:get_meta():get_string(key)
+		local meta = player:get_meta()
+		return meta and meta:get_string(key) or ""
 	else
 		return player:get_attribute(key)
 	end

--- a/init.lua
+++ b/init.lua
@@ -66,10 +66,11 @@ end
 
 local function set_player_attribute(player, key, value)
 	if player.get_meta then
-		if value == nil then
-			player:get_meta():set_string(key, "")
-		else
-			player:get_meta():set_string(key, tostring(value))
+		local meta = player:get_meta()
+		if meta and value == nil then
+			meta:set_string(key, "")
+		elseif meta then
+			meta:set_string(key, tostring(value))
 		end
 	else
 		player:set_attribute(key, value)


### PR DESCRIPTION
This is fairly uncommon crash, similar has happened with other mods and similar fixes were pushed around.
For me it seems to be some fairly recent change on engine itself (5.3 or 5.4 possibly?).

Basically what happens is that player is gone but instance of player object is still partially valid, it will return some thing but a lot is missing. For example `get_meta()` can return `nil`. It seems to be most likely if we're running entity step (and player disappears / disconnected just before).

(similar seems to possibly happen if client crashes at the end of connection / joining process, not this bug necessarily but similar incomplete player instance)