### PR TITLE
show particles while eating foods without an inventory image

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,0 @@
-default
-3d_armor?
-player_monoids?

--- a/description.txt
+++ b/description.txt
@@ -1,1 +1,0 @@
-Adds stamina and hunger effects.

--- a/init.lua
+++ b/init.lua
@@ -299,7 +299,7 @@ function stamina.set_sprinting(player, sprinting)
 	end
 
 	if settings.sprint_particles and sprinting then
-		local pos = player:getpos()
+		local pos = player:get_pos()
 		local node = minetest.get_node({x = pos.x, y = pos.y - 1, z = pos.z})
 		local def = minetest.registered_nodes[node.name] or {}
 		local drawtype = def.drawtype
@@ -429,8 +429,8 @@ end
 
 local function show_eat_particles(player, itemname)
 	-- particle effect when eating
-	local pos = player:getpos()
-	pos.y = pos.y + 1.5 -- mouth level
+	local pos = player:get_pos()
+	pos.y = pos.y + (player:get_properties().eye_height * .923) -- assume mouth is slightly below eye_height
 	local dir = player:get_look_dir()
 
 	local def = minetest.registered_items[itemname]
@@ -516,7 +516,7 @@ function minetest.do_item_eat(hp_change, replace_with_item, itemstack, player, p
 			if inv:room_for_item("main", {name=replace_with_item}) then
 				inv:add_item("main", replace_with_item)
 			else
-				local pos = player:getpos()
+				local pos = player:get_pos()
 				pos.y = math.floor(pos.y - 1.0)
 				minetest.add_item(pos, replace_with_item)
 			end

--- a/init.lua
+++ b/init.lua
@@ -427,6 +427,43 @@ local function stamina_globaltimer(dtime)
 	end
 end
 
+local function show_eat_particles(player, itemname)
+	-- particle effect when eating
+	local pos = player:getpos()
+	pos.y = pos.y + 1.5 -- mouth level
+	local dir = player:get_look_dir()
+
+	local def = minetest.registered_items[itemname]
+	local texture = def.inventory_image or def.wield_image
+
+	local particle_def = {
+		amount = 5,
+		time = 0.1,
+		minpos = pos,
+		maxpos = pos,
+		minvel = {x = dir.x - 1, y = dir.y, z = dir.z - 1},
+		maxvel = {x = dir.x + 1, y = dir.y, z = dir.z + 1},
+		minacc = {x = 0, y = -5, z = 0},
+		maxacc = {x = 0, y = -9, z = 0},
+		minexptime = 1,
+		maxexptime = 1,
+		minsize = 1,
+		maxsize = 2,
+	}
+
+	if texture and texture ~= "" then
+		particle_def.texture = texture
+
+	elseif def.type == "node" then
+		particle_def.node = {name = itemname, param2 = 0}
+
+	else
+		particle_def.texture = "blank.png"
+	end
+
+	minetest.add_particlespawner(particle_def)
+end
+
 -- override minetest.do_item_eat() so we can redirect hp_change to stamina
 stamina.core_item_eat = minetest.do_item_eat
 function minetest.do_item_eat(hp_change, replace_with_item, itemstack, player, pointed_thing)
@@ -466,27 +503,7 @@ function minetest.do_item_eat(hp_change, replace_with_item, itemstack, player, p
 	end
 
 	if settings.eat_particles then
-		-- particle effect when eating
-		local pos = player:getpos()
-		pos.y = pos.y + 1.5 -- mouth level
-		local texture  = minetest.registered_items[itemname].inventory_image
-		local dir = player:get_look_dir()
-
-		minetest.add_particlespawner({
-			amount = 5,
-			time = 0.1,
-			minpos = pos,
-			maxpos = pos,
-			minvel = {x = dir.x - 1, y = dir.y, z = dir.z - 1},
-			maxvel = {x = dir.x + 1, y = dir.y, z = dir.z + 1},
-			minacc = {x = 0, y = -5, z = 0},
-			maxacc = {x = 0, y = -9, z = 0},
-			minexptime = 1,
-			maxexptime = 1,
-			minsize = 1,
-			maxsize = 2,
-			texture = texture,
-		})
+		show_eat_particles(player, itemname)
 	end
 
 	itemstack:take_item()

--- a/init.lua
+++ b/init.lua
@@ -331,7 +331,7 @@ local function move_tick()
 	for _,player in ipairs(minetest.get_connected_players()) do
 		local controls = player:get_player_control()
 		local is_moving = controls.up or controls.down or controls.left or controls.right
-		local velocity = player:get_player_velocity()
+		local velocity = player:get_velocity()
 		velocity.y = 0
 		local horizontal_speed = vector.length(velocity)
 		local has_velocity = horizontal_speed > 0.05

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,6 @@
 name = stamina
 title = Stamina
 description = Adds stamina and hunger effects.
+min_minetest_version = 5.4
 depends = default
 optional_depends = 3d_armor, player_monoids

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,5 @@
 name = stamina
+title = Stamina
+description = Adds stamina and hunger effects.
+depends = default
+optional_depends = 3d_armor, player_monoids


### PR DESCRIPTION
currently, if a food has no inventory image (or wield image), stamina will show particles of a randomly chosen color when you eat. 

![screenshot_20221025_142931](https://user-images.githubusercontent.com/25628292/197889128-d86111f7-a750-455e-bc8a-f226e164e4d3.png)

in the case where the food is a node, the particles can instead by generated as the particles that would appear if you dug the node.

![screenshot_20221025_144915](https://user-images.githubusercontent.com/25628292/197889162-9e0d4052-3112-4594-b1c5-6fe8caf721cd.png)

unfortunately there doesn't seem to be a way to get that effect to respect the node's texture's alpha channel.. but it's an improvement.