### PR TITLE
Hp change reasons retry

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -175,7 +175,7 @@ local function poison_tick(player_name, ticks, interval, elapsed)
 	else
 		local hp = player:get_hp() - 1
 		if hp > 0 then
-			player:set_hp(hp, "stamina:poison")
+			player:set_hp(hp, {type = "set_hp", cause = "stamina:poison"})
 		end
 		minetest.after(interval, poison_tick, player_name, ticks, interval, elapsed + 1)
 	end
@@ -394,10 +394,10 @@ local function health_tick()
 		)
 
 		if should_heal then
-			player:set_hp(hp + settings.heal, "stamina:heal")
+			player:set_hp(hp + settings.heal, {type = "set_hp", cause = "stamina:heal"})
 			stamina.exhaust_player(player, settings.exhaust_lvl, stamina.exhaustion_reasons.heal)
 		elseif is_starving then
-			player:set_hp(hp - settings.starve, "stamina:starve")
+			player:set_hp(hp - settings.starve, {type = "set_hp", cause = "stamina:starve"})
 		end
 	end
 end


### PR DESCRIPTION
when trying to make use of #41 in practice, i've learned that a string passed as the "reason" is silently ignored. the reason must be a table. hence, attempt #2. i've actually tested it w/ a death message mod this time. 