### PR TITLE
check that hp is less than hp_max when trying to heal

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -377,12 +377,14 @@ local function health_tick()
 	for _,player in ipairs(minetest.get_connected_players()) do
 		local air = player:get_breath() or 0
 		local hp = player:get_hp()
+		local hp_max = player:get_properties().hp_max
 		local saturation = stamina.get_saturation(player)
 
 		-- don't heal if dead, drowning, or poisoned
 		local should_heal = (
 			saturation >= settings.heal_lvl and
 			saturation >= hp and
+			hp < hp_max and
 			hp > 0 and
 			air > 0
 			and not stamina.is_poisoned(player)


### PR DESCRIPTION
currently, if hp_max is less than the max saturation, heal ticks will drain stamina quickly while doing nothing.

currently, if hp_max is greater than max saturation, healing will max out at max saturation.

this PR changes the behavior to cause healing to occur so long as saturation is high enough and hp is less than hp_max. 