### PR TITLE
allow healing when max_hp is higher than max stamina

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -383,7 +383,6 @@ local function health_tick()
 		-- don't heal if dead, drowning, or poisoned
 		local should_heal = (
 			saturation >= settings.heal_lvl and
-			saturation >= hp and
 			hp < hp_max and
 			hp > 0 and
 			air > 0


### PR DESCRIPTION
currently, healing is only allowed if saturation is above the current hp level. however, if max_hp is larger than max_saturation (20), healing will stop at 20 even if it's possible to heal more. 