### PR TITLE
behavior tweaks when eating "empty" food

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -481,8 +481,8 @@ function minetest.do_item_eat(hp_change, replace_with_item, itemstack, player, p
 	end
 
 	local level = stamina.get_saturation(player) or 0
-	if level >= settings.visual_max then
-		-- don't eat if player is full
+	if level >= settings.visual_max and hp_change > 0 then
+		-- don't eat if player is full and item provides saturation
 		return itemstack
 	end
 

--- a/init.lua
+++ b/init.lua
@@ -499,8 +499,7 @@ function minetest.do_item_eat(hp_change, replace_with_item, itemstack, player, p
 	if hp_change > 0 then
 		stamina.change_saturation(player, hp_change)
 		stamina.set_exhaustion(player, 0)
-	else
-		-- assume hp_change < 0.
+	elseif hp_change < 0 then
 		stamina.poison(player, -hp_change, settings.poison_tick)
 	end
 


### PR DESCRIPTION
two minor changes:
1. when the player is at max saturation, allow eating items if they do not add saturation. this allows for consumption of items that apply other effects but use `do_item_eat` for the callbacks, replacement items, etc. 
2. don't set poisoned status when eating something that adds 0 saturation. 